### PR TITLE
Fix issue with page not loading on GH pages + random fixes

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -1,4 +1,4 @@
-export const to_image_name = (tarot) => Number.parseInt(tarot) === 0 ? 'j-.jpg' : `j-${tarot}.jpg`;
+export const to_image_name = (tarot) => `j-${tarot}.jpg`;
 
 const register = async () => {
   try {

--- a/lib.js
+++ b/lib.js
@@ -2,7 +2,8 @@ export const to_image_name = (tarot) => Number.parseInt(tarot) === 0 ? 'j-.jpg' 
 
 const register = async () => {
   try {
-    const registration = await navigator.serviceWorker.register("/sworker.js", { scope: "/", type: "module" });
+    const scope = window.location.pathname; // This assumes the page will be an index.html page.
+    const registration = await navigator.serviceWorker.register("sworker.js", { scope, type: "module" });
     switch (true) {
       case !!registration.installing: 
         console.info("service worker installing");

--- a/sketch.js
+++ b/sketch.js
@@ -4,12 +4,9 @@ import { install, to_image_name, location_to_tarot } from './lib.js';
 const STORAGE_KEY_KEY = 'oracle_key';
 const KEY_FREE = 'free';
 
-// FIXME: Warning: naive interpolate.
-const translate = (x) => Math.round((100 / 255) * x);
-
 const toRequest = (key) => {
   if (key && key !== KEY_FREE) {
-    const url = new URL('https://api.quantumnumbers.anu.edu.au?length=1&type=uint8');
+    const url = new URL('https://api.quantumnumbers.anu.edu.au?length=8&type=uint8');
     const options = {
       headers: {
         'x-api-key': key 
@@ -18,7 +15,7 @@ const toRequest = (key) => {
     const request = new Request(url, options);
     return request;
   } else {
-    const url = new URL('https://qrng.anu.edu.au/API/jsonI.php?length=1&type=uint8');
+    const url = new URL('https://qrng.anu.edu.au/API/jsonI.php?length=16&type=uint8');
     const request = new Request(url);
     return request;
   }
@@ -32,7 +29,7 @@ const call = async () => {
   if (!json.success) {
     throw new Error("API Failure", { cause: json });
   }
-  return json.data[0];
+  return json.data;
 }
 
 const load = (image_name) => {
@@ -49,10 +46,14 @@ const show = (tarot) => {
   notify(tarot);
 }
 
+// the Brain algorithm. May loop forever, in flagrent display of irony.
 const reading = async () => {
-  const data = await call();
-  const tarot = translate(data, 0, 100);
-  show(tarot);
+  let x;
+  while(x === undefined) {
+    const data = await call();
+    x = data.find(n => n < 200);
+  }
+  show(x % 100 + 1);
 }
 
 const start = () => {

--- a/sworker.js
+++ b/sworker.js
@@ -17,9 +17,9 @@ const fetchCache = async (request) => {
 }
 
 const get_image_names = () => {
-  const total = 101;
+  const total = 100;
   const image_names = [];
-  for (let n = 0; n < total; n++) {
+  for (let n = 1; n <= total; n++) {
     image_names.push(`./${to_image_name(n)}`);
   }
   return image_names;


### PR DESCRIPTION
The original service worker designed assumed the site was running on the root of localhost. This simple fix should load the service work relatively and scope it to the relative path

This also fixes issues with the number of images being 100, and no longer 101 and replaces the low quality interpolate method with one that preserves the uniform distribution of tarot cards selected.